### PR TITLE
Added support to paste flows exported from editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Using the test-helper, your tests can start the Node-RED runtime, load a flow an
 
 ## Adding to your node project dependencies
 
-To add unit tests your node project test dependencies, add this test helper as follows:
+To add unit tests to your node project test dependencies, add this test helper as follows:
 
     npm install node-red-node-test-helper --save-dev
 
@@ -21,6 +21,32 @@ This will add the helper module to your `package.json` file as a development dep
 ```
 
 Both [Mocha](https://mochajs.org/) and [Should](https://shouldjs.github.io/) will be pulled in with the test helper.  Mocha is a unit test framework for Javascript; Should is an assertion library.  For more information on these frameworks, see their associated documentation.
+
+## Alternate linking of node project dependencies
+
+Instead of installing the unit test node project test dependencies, which can pull in a very large number of packages, you can install the unit test packages globally and link them to your node project.  This is a better option if you plan on developing more than one node project.
+
+Install the unit test packages globally as follows:
+
+    npm install -g node-red
+    npm install -g node-red-node-test-helper
+    npm install -g should
+    npm install -g mocha
+    npm install -g sinon
+    npm install -g supertest
+    npm install -g express
+
+In your node project development directory, link the unit test packages as follows:
+
+    npm link node-red
+    npm link node-red-node-test-helper
+    npm link should
+    npm link mocha
+    npm link sinon
+    npm link supertest
+    npm link express
+
+Depending on the nodes in your test flow, you may also need to link in other packages as required.  If a test indicates that a package cannot be found, install the package globally and then link it to your node project the same way as the packages above.
 
 ## Adding test script to `package.json`
 
@@ -88,6 +114,14 @@ In this example, we require `should` for assertions, this helper module, as well
 
 We then have a set of mocha unit tests.  These tests check that the node loads correctly, and ensures it makes the payload string lower case as expected.
 
+## Creating test flows in the Node Red editor
+
+The Node Red editor can be used to generate test flow configurations.  Create a flow in the editor with the node you wish to test and configure them using the node configuration editor. Add `debug` nodes to receive output messages from your test node. `catch` and `status` nodes can also be used to catch errors and status changes from your test node.  It is not necessary to include `inject` nodes as this helper module will allow you to inject test messages.
+
+Highlight the nodes in the test flow and select `Export` then `Clipboard` to copy your test flow configuration, and then paste the JSON string into the test script.  Repeat this process to create different variations of your test flow if required.
+
+When the flow is run in this helper module, `debug` nodes are converted to `helper` nodes.
+
 ## Getting nodes in the runtime
 
 The asynchronous `helper.load()` method calls the supplied callback function once the Node-RED server and runtime is ready.  We can then call the `helper.getNode(id)` method to get a reference to nodes in the runtime.  For more information on these methods see the API section below.
@@ -128,7 +162,7 @@ For additional test examples, see the `.js` files supplied in the `test/examples
 Loads a flow then starts the flow. This function has the following arguments:
 
 * testNode: (object|array of objects) Module object of a node to be tested returned by require function. This node will be registered, and can be used in testFlows.
-* testFlows: (array of objects) Flow data to test a node. If you want to use the flow data exported from Node-RED editor, need to covert it to JavaScript object using JSON.parse().
+* testFlows: (array of objects|JSON string)) Flow configuration to test a node. The flow configuration can be exported from Node-RED editor and pasted as a JSON string.
 * testCredentials: (object) Optional node credentials.
 * cb: (function) Function to call back when testFlows has been started.
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     },
     {
       "name": "Mike Blackstock"
+    },
+    {
+      "name": "Dean Cording"
     }
   ],
   "keywords": [

--- a/test/function_spec.js
+++ b/test/function_spec.js
@@ -29,6 +29,10 @@ describe('function node', function() {
         helper.unload();
     });
 
+    after(function(done) {
+        helper.stopServer(done);
+    });
+
     it('should be loaded', function(done) {
         var flow = [{id:"n1", type:"function", name: "function" }];
         helper.load(functionNode, flow, function() {

--- a/test/httprequest_spec.js
+++ b/test/httprequest_spec.js
@@ -64,6 +64,7 @@ describe('HTTP Request Node', function() {
 
     after(function() {
         testServer.close();
+        helper.stopServer();
     });
     afterEach(function() {
         helper.unload();

--- a/test/lower-case_spec.js
+++ b/test/lower-case_spec.js
@@ -9,22 +9,29 @@ describe('lower-case Node', function () {
   });
 
   it('should be loaded', function (done) {
-    var flow = [{ id: "n1", type: "lower-case", name: "lower-case" }];
+
+    // Exported flow pasted as JSON string
+    var flow = '[{"id":"3912a37a.c3818c","type":"lower-case","z":"e316ac4b.c85a2","name":"lower-case","x":240,"y":320,"wires":[[]]}]';
+
     helper.load(lowerNode, flow, function () {
-      var n1 = helper.getNode("n1");
+      var n1 = helper.getNode("3912a37a.c3818c");
       n1.should.have.property('name', 'lower-case');
       done();
     });
   });
 
   it('should make payload lower case', function (done) {
-    var flow = [
-      { id: "n1", type: "lower-case", name: "test name",wires:[["n2"]] },
-      { id: "n2", type: "helper" }
-    ];
+
+    // Exported flow pasted as Javascript
+    var flow = [{"id":"3912a37a.c3818c","type":"lower-case","z":"e316ac4b.c85a2",
+                    "name":"lower-case","x":240,"y":320,"wires":[["7b57d83e.378fd8"]]},
+                {"id":"7b57d83e.378fd8","type":"debug","z":"e316ac4b.c85a2","name":"",
+                    "active":true,"tosidebar":true,"console":false,"tostatus":false,
+                    "complete":"true","x":400,"y":340,"wires":[]}];
+
     helper.load(lowerNode, flow, function () {
-      var n2 = helper.getNode("n2");
-      var n1 = helper.getNode("n1");
+      var n2 = helper.getNode("7b57d83e.378fd8");
+      var n1 = helper.getNode("3912a37a.c3818c");
       n2.on("input", function (msg) {
         msg.should.have.property('payload', 'uppercase');
         done();

--- a/test/websocket_spec.js
+++ b/test/websocket_spec.js
@@ -66,6 +66,10 @@ describe('websocket Node', function() {
         helper.unload();
     });
 
+    after(function(done) {
+        helper.stopServer(done);
+    });
+
     describe('websocket-listener', function() {
         it('should load', function(done) {
             var flow = [{ id: "n1", type: "websocket-listener", path: "/ws" }];


### PR DESCRIPTION
- Allows flows to be create in editor and pasted into test scripts as JSON string.  Backwards compatible with existing test flow definitions.
- Automatically creates a flow to hold the test nodes so that Catch and Status nodes work.
- Automatically converts Debug nodes into Helper nodes so that links can be set up between nodes using the editor.
- Adds error handler to override node error handler so that test failures are passed back to mocha and not swallowed by Node Red
- Fixes some existing tests that fail the stop the help server after tests are completed.
- Documentation added for linking dependencies instead of installing them.