### PR TITLE
fix glob in test script for cross-platform portability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A test framework for Node-RED nodes",
   "main": "index.js",
   "scripts": {
-    "test": "mocha 'test/**/*_spec.js'"
+    "test": "mocha \"test/**/*_spec.js\""
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This glob will fail to work as expected in a Windows environment as written.  Double quotes will cause this to work as expected.