### PR TITLE
remove unused devDependency hash-sum

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "supertest": "3.0.0",
     "when": "3.7.8"
   },
-  "devDependencies": {
-    "hash-sum": "1.0.2"
-  },
+  "devDependencies": {},
   "contributors": [
     {
       "name": "Nick O'Leary"


### PR DESCRIPTION
I didn't see `hash-sum` used anywhere.