### PR TITLE
add helper.init() call to supply NR runtime path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This will add the helper module to your `package.json` file as a development dep
 ...
 ```
 
-The test-helper requires the node-red runtime to run its tests, but Node-RED is **not** installed as a dependency.  The reason for this is that test-helper is (or will be) used in Node-RED core tests, and Node-RED itself has a large number of dependencies that you may not want to download if you already have it installed.
+The test-helper requires the node-red runtime, but Node-RED is **not** installed as a dependency.  The reason for this is that test-helper is (or will be) used in Node-RED core tests, and Node-RED itself has a large number of dependencies that you may not want to download if you already have it installed.
 
 You can install the Node-RED runtime available for your unit tests one of two ways:
 
@@ -30,7 +30,7 @@ You can install the Node-RED runtime available for your unit tests one of two wa
 npm install node-red --save-dev
 ```
 
-2. or link to Node-RED installed globally (recommended) using:
+2. or link to Node-RED installed globally using:
 
 ```
 npm install -g node-red
@@ -84,6 +84,8 @@ var should = require("should");
 var helper = require("node-red-node-test-helper");
 var lowerNode = require("../lower-case.js");
 
+helper.init(require.resolve('node-red'));
+
 describe('lower-case Node', function () {
 
   afterEach(function () {
@@ -120,6 +122,10 @@ describe('lower-case Node', function () {
 In this example, we require `should` for assertions, this helper module, as well as the `lower-case` node we want to test, located in the parent directory.
 
 We then have a set of mocha unit tests.  These tests check that the node loads correctly, and ensures it makes the payload string lower case as expected.
+
+## Initializing helper
+
+To get started, we need to tell the helper where to find the node-red runtime.  this is done by calling `helper.init(require.resolve('node-red'))` as shown.
 
 ## Getting nodes in the runtime
 

--- a/README.md
+++ b/README.md
@@ -6,54 +6,20 @@ Using the test-helper, your tests can start the Node-RED runtime, load a test fl
 
 ## Adding to your node project dependencies
 
-To add unit tests your node project test dependencies, add this test helper as follows:
+Node-RED is required by the helper as a peer dependency, meaning it must be installed along with the helper itself.  To create unit tests for your node project, add this test helper and Node-RED as follows:
 
-    npm install node-red-node-test-helper --save-dev
+    npm install node-red-node-test-helper node-red --save-dev
 
-This will add the helper module to your `package.json` file as a development dependency:
+This will add and the helper module to your `package.json` file:
 
 ```json
 ...
   "devDependencies": {
+    "node-red":"^0.18.4",
     "node-red-node-test-helper": "^0.1.6"
   }
 ...
 ```
-
-The test-helper requires the node-red runtime, but Node-RED is **not** installed as a dependency.  The reason for this is that test-helper is (or will be) used in Node-RED core tests, and Node-RED itself has a large number of dependencies that you may not want to download if you already have it installed.
-
-You can install the Node-RED runtime available for your unit tests one of two ways:
-
-1. as a dev dependency in your project:
-
-```
-npm install node-red --save-dev
-```
-
-2. or link to Node-RED installed globally using:
-
-```
-npm install -g node-red
-npm link node-red
-```
-
-Both [Mocha](https://mochajs.org/) and [Should](https://shouldjs.github.io/) will be pulled in with the test helper.  Mocha is a unit test framework for Javascript; Should is an assertion library.  For more information on these frameworks, see their associated documentation.
-
-## Linking to additional test dependencies
-
-To reduce disk use further, you can install the test-helper and additional dev dependencies globally and then link them to your node project.  This may be a better option especially if you are developing more than one node.
-
-See the `package.json` file for the additional dependencies used by test-helper.
-
-For example to install express globally:
-
-    npm install -g express
-
-Then link to it in your project:
-
-    npm link express
-
-Depending on the nodes in your test flow, you may also want to link to other global packages.  If a test indicates that a package cannot be found, and you expect to need it for testing other nodes, consider installing the package globally and then linking it to your node project the same way.
 
 ## Adding test script to `package.json`
 
@@ -123,7 +89,7 @@ In this example, we require `should` for assertions, this helper module, as well
 
 We then have a set of mocha unit tests.  These tests check that the node loads correctly, and ensures it makes the payload string lower case as expected.
 
-## Initializing helper
+## Initializing Helper
 
 To get started, we need to tell the helper where to find the node-red runtime.  this is done by calling `helper.init(require.resolve('node-red'))` as shown.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Node-RED is required by the helper as a peer dependency, meaning it must be inst
 
     npm install node-red-node-test-helper node-red --save-dev
 
-This will add and the helper module to your `package.json` file:
+This will add the helper module to your `package.json` file:
 
 ```json
 ...

--- a/examples/comment_spec.js
+++ b/examples/comment_spec.js
@@ -16,6 +16,8 @@
 
 var should = require("should");
 var helper = require("../index.js");
+helper.init(require.resolve('node-red'));
+
 var commentNode = require("./nodes/90-comment.js");
 
 describe('comment Node', function() {

--- a/examples/function_spec.js
+++ b/examples/function_spec.js
@@ -16,6 +16,7 @@
 
 var should = require("should");
 var helper = require("../index.js");
+helper.init(require.resolve('node-red'));
 
 var functionNode = require("./nodes/80-function.js");
 

--- a/examples/lower-case_spec.js
+++ b/examples/lower-case_spec.js
@@ -2,6 +2,8 @@ var should = require("should");
 var helper = require("../index.js");
 var lowerNode = require("./nodes/lower-case.js");
 
+helper.init(require.resolve('node-red'));
+
 describe('lower-case Node', function () {
 
   afterEach(function () {

--- a/index.js
+++ b/index.js
@@ -22,27 +22,41 @@ var express = require("express");
 var http = require('http');
 var stoppable = require('stoppable');
 
-try {
-    var RED = require('node-red');
-    var redNodes = require("node-red/red/runtime/nodes");
-    var flows = require("node-red/red/runtime/nodes/flows");
-    var credentials = require("node-red/red/runtime/nodes/credentials");
-    var comms = require("node-red/red/api/editor/comms.js");
-    var log = require("node-red/red/runtime/log.js");
-    var context = require("node-red/red/runtime/nodes/context.js");
-    var events = require('node-red/red/runtime/events');
-} catch (err) {
-    // no node-red in helper-test dependencies so assume we're testing node-red
-    var nrPath = process.cwd();
-    var RED = require(nrPath+"/red/red.js");
-    var redNodes = require(nrPath+"/red/runtime/nodes");
-    var flows = require(nrPath+"/red/runtime/nodes/flows");
-    var credentials = require(nrPath+"/red/runtime/nodes/credentials");
-    var comms = require(nrPath+"/red/api/editor/comms.js");
-    var log = require(nrPath+"/red/runtime/log.js");
-    var context = require(nrPath+"/red/runtime/nodes/context.js");
-    var events = require(nrPath+"/red/runtime/events.js");
+var RED;
+var redNodes;
+var flows;
+var credentials;
+var comms;
+var log;
+var context;
+var events;
+
+function initRuntime(requirePath) {
+
+    try {
+        RED = require(requirePath);
+        var prefix = requirePath.substring(0, requirePath.indexOf('/red.js'));
+        redNodes = require(prefix+"/runtime/nodes");
+        flows = require(prefix+"/runtime/nodes/flows");
+        credentials = require(prefix+"/runtime/nodes/credentials");
+        comms = require(prefix+"/api/editor/comms");
+        log = require(prefix+"/runtime/log");
+        context = require(prefix+"/runtime/nodes/context");
+        events = require(prefix+"/runtime/events");
+    } catch (err) {
+        // ignore, assume init will be called again by a test script supplying the runtime path
+    }
 }
+
+// assume we have node red as a dependency
+try {
+    var runtimePath = require.resolve('node-red');
+} catch (err) {
+    // if not, we are running in the core
+    runtimePath = process.cwd()+"/red/red.js";
+}
+
+initRuntime(runtimePath);
 
 var app = express();
 
@@ -58,6 +72,7 @@ function helperNode(n) {
 }
 
 module.exports = {
+    init: initRuntime,
     load: function(testNode, testFlow, testCredentials, cb) {
         var i;
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = {
         };
 
         redNodes.init({events:events,settings:settings, storage:storage,log:log,});
-        RED.nodes.registerType("helper", helperNode);
+        redNodes.registerType("helper", helperNode);
         if (Array.isArray(testNode)) {
             for (i = 0; i < testNode.length; i++) {
                 testNode[i](red);

--- a/index.js
+++ b/index.js
@@ -58,7 +58,6 @@ function initRuntime(requirePath) {
 
         // access internal Node-RED runtime methods
         var prefix = requirePath.substring(0, requirePath.indexOf('/red.js'));
-        flows = require(prefix+"/runtime/nodes/flows");
         context = require(prefix+"/runtime/nodes/context");
         comms = require(prefix+"/api/editor/comms");
     } catch (err) {
@@ -148,8 +147,7 @@ module.exports = {
     },
 
     getNode: function(id) {
-        // internal API
-        return flows.get(id);
+        return redNodes.getNode(id);
     },
 
     clearFlows: function() {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   },
   "dependencies": {
     "express": "4.16.2",
+    "read-pkg-up": "^3.0.0",
     "should": "^8.4.0",
     "sinon": "1.17.7",
-    "supertest": "3.0.0",
     "stoppable": "boneskull/stoppable#boneskull-patch-1",
+    "supertest": "3.0.0",
     "when": "3.7.8"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
   },
   "dependencies": {
     "express": "4.16.2",
-    "read-pkg-up": "^3.0.0",
-    "should": "^8.4.0",
+    "read-pkg-up": "3.0.0",
+    "should": "8.4.0",
     "sinon": "1.17.7",
-    "stoppable": "boneskull/stoppable#boneskull-patch-1",
+    "stoppable": "1.0.6",
     "supertest": "3.0.0",
     "when": "3.7.8"
   },
   "peerDependencies": {
-    "node-red": "0.18.x"
+    "node-red": "~0.18.4"
   },
   "devDependencies": {
     "mocha": "~5.0.4"


### PR DESCRIPTION
runtime initialization moved to a method so node tests can supply the node-red runtime path.
if it can find node-red in its dependencies, or it is running in the core, initialization is (still) not needed.
