### PR TITLE
Fix filepath for Windows OS

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,10 +58,10 @@ function initRuntime(requirePath) {
         log = RED.log;
 
         // access internal Node-RED runtime methods
-        var prefix = requirePath.substring(0, requirePath.indexOf('/red.js'));
-        context = require(prefix+"/runtime/nodes/context");
-        comms = require(prefix+"/api/editor/comms");
-        credentials = require(prefix+"/runtime/nodes/credentials");
+        var prefix = requirePath.substring(0, requirePath.indexOf('red.js'));
+        context = require(prefix+"runtime/nodes/context");
+        comms = require(prefix+"api/editor/comms");
+        credentials = require(prefix+"runtime/nodes/credentials");
 
     } catch (err) {
         // ignore, assume init will be called again by a test script supplying the runtime path


### PR DESCRIPTION
## Types of changes

I fixed #14 

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Remove the Linux peculiar separator `/` from argument of indexOf function.  
And remove `/` from joined paths because `prefix` ends with separator due to above fix. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `mocha test/_spec.js` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality

