### PR TITLE
add range node example …

### DIFF
--- a/examples/nodes/16-range.js
+++ b/examples/nodes/16-range.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+module.exports = function(RED) {
+  "use strict";
+  function RangeNode(n) {
+      RED.nodes.createNode(this, n);
+      this.action = n.action;
+      this.round = n.round || false;
+      this.minin = Number(n.minin);
+      this.maxin = Number(n.maxin);
+      this.minout = Number(n.minout);
+      this.maxout = Number(n.maxout);
+      this.property = n.property||"payload";
+      var node = this;
+
+      this.on('input', function (msg) {
+          var value = RED.util.getMessageProperty(msg,node.property);
+          if (value !== undefined) {
+              var n = Number(value);
+              if (!isNaN(n)) {
+                  if (node.action == "clamp") {
+                      if (n < node.minin) { n = node.minin; }
+                      if (n > node.maxin) { n = node.maxin; }
+                  }
+                  if (node.action == "roll") {
+                      var divisor = node.maxin - node.minin;
+                      n = ((n - node.minin) % divisor + divisor) % divisor + node.minin;
+                  }
+                  value = ((n - node.minin) / (node.maxin - node.minin) * (node.maxout - node.minout)) + node.minout;
+                  if (node.round) { value = Math.round(value); }
+                  RED.util.setMessageProperty(msg,node.property,value);
+                  node.send(msg);
+              }
+              else { node.log(RED._("range.errors.notnumber")+": "+value); }
+          }
+          else { node.send(msg); } // If no payload - just pass it on.
+      });
+  }
+  RED.nodes.registerType("range", RangeNode);
+}

--- a/examples/range_spec.js
+++ b/examples/range_spec.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+var should = require("should");
+
+var rangeNode = require("./nodes/16-range.js");
+var helper = require("../index.js");
+
+describe('range Node', function() {
+
+    beforeEach(function(done) {
+        helper.startServer(done);
+    });
+
+    afterEach(function(done) {
+        helper.unload();
+        helper.stopServer(done);
+    });
+
+    it('should load some defaults', function(done) {
+        var flow = [{"id":"rangeNode1","type":"range","name":"rangeNode"}];
+        helper.load(rangeNode, flow, function() {
+            var rangeNode1 = helper.getNode("rangeNode1");
+            rangeNode1.should.have.property('name', 'rangeNode');
+            rangeNode1.should.have.property('round', false);
+            done();
+        });
+    });
+
+    /**
+     * Run a generic range test
+     * @param action - scale/clamp (range limit)/roll (modulo): what action to choose
+     * @param minin - map from minimum value
+     * @param maxin - map from maximum value
+     * @param minout - map to minimum value
+     * @param maxout - map to maximum value
+     * @param round - whether to round the result to the nearest integer
+     * @param aPayload - what payload to send to the range node
+     * @param expectedResult - what result we're expecting
+     * @param done - the callback to call when test done
+     */
+    function genericRangeTest(action, minin, maxin, minout, maxout, round, aPayload, expectedResult, done) {
+        var flow = [{"id":"rangeNode1","type":"range","minin":minin,"maxin":maxin,"minout":minout,"maxout":maxout,"action":action,"round":round,"name":"rangeNode","wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(rangeNode, flow, function() {
+            var rangeNode1 = helper.getNode("rangeNode1");
+            var helperNode1 = helper.getNode("helperNode1");
+            helperNode1.on("input", function(msg) {
+                try {
+                    msg.payload.should.equal(expectedResult);
+                    done();
+                } catch(err) {
+                    done(err);
+                }
+            });
+            rangeNode1.receive({payload:aPayload});
+        });
+    }
+
+    it('ranges numbers up tenfold', function(done) {
+        genericRangeTest("scale", 0, 100, 0, 1000, false, 50, 500, done);
+    });
+
+    it('ranges numbers down such as centimetres to metres', function(done) {
+        genericRangeTest("scale", 0, 100, 0, 1, false, 55, 0.55, done);
+    });
+
+    it('wraps numbers down say for degree/rotation reading 1/2', function(done) {
+        genericRangeTest("roll", 0, 10, 0, 360, true, 15, 180, done); // 1/2 around wrap => "one and a half turns"
+    });
+
+    it('wraps numbers around say for degree/rotation reading 1/3', function(done) {
+        genericRangeTest("roll", 0, 10, 0, 360, true, 13.3333, 120, done); // 1/3 around wrap => "one and a third turns"
+    });
+
+    it('wraps numbers around say for degree/rotation reading 1/4', function(done) {
+        genericRangeTest("roll", 0, 10, 0, 360, true, 12.5, 90, done); // 1/4 around wrap => "one and a quarter turns"
+    });
+
+    it('wraps numbers down say for degree/rotation reading 1/4', function(done) {
+        genericRangeTest("roll", 0, 10, 0, 360, true, -12.5, 270, done); // 1/4 backwards wrap => "one and a quarter turns backwards"
+    });
+
+    it('wraps numbers around say for degree/rotation reading 0', function(done) {
+        genericRangeTest("roll", 0, 10, 0, 360, true, -10, 0, done);
+    });
+
+    it('clamps numbers within a range - over max', function(done) {
+        genericRangeTest("clamp", 0, 10, 0, 1000, false, 111, 1000, done);
+    });
+
+    it('clamps numbers within a range - below min', function(done) {
+        genericRangeTest("clamp", 0, 10, 0, 1000, false, -1, 0, done);
+    });
+
+    it('just passes on msg if payload not present', function(done) {
+        var flow = [{"id":"rangeNode1","type":"range","minin":0,"maxin":100,"minout":0,"maxout":100,"action":"scale","round":true,"name":"rangeNode","wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(rangeNode, flow, function() {
+            var rangeNode1 = helper.getNode("rangeNode1");
+            var helperNode1 = helper.getNode("helperNode1");
+            helperNode1.on("input", function(msg) {
+                try {
+                    msg.should.not.have.property('payload');
+                    msg.topic.should.equal("pass on");
+                    done();
+                } catch(err) {
+                    done(err);
+                }
+            });
+            rangeNode1.receive({topic:"pass on"});
+        });
+    });
+
+    it('reports if input is not a number', function(done) {
+        var flow = [{"id":"rangeNode1","type":"range","minin":0,"maxin":0,"minout":0,"maxout":0,"action":"scale","round":true,"name":"rangeNode","wires":[["helperNode1"]]},
+                    {id:"helperNode1", type:"helper", wires:[]}];
+        helper.load(rangeNode, flow, function() {
+            var rangeNode1 = helper.getNode("rangeNode1");
+
+            // new helper node events
+            rangeNode1.on('call:log', call => {
+                if (call.args[0].indexOf("notnumber") > -1) {
+                    done();
+                } else {
+                    try {
+                        should.fail(null, null, "Non-number inputs should be reported!");
+                    } catch (err) {
+                        done(err);
+                    }
+                }
+            });
+
+            rangeNode1.receive({payload:"NOT A NUMBER"});
+        });
+    });
+});

--- a/test/_spec.js
+++ b/test/_spec.js
@@ -1,11 +1,108 @@
-var should = require("should");
-var helper = require('../index.js');
+const should = require('should');
+const path = require('path');
 
-describe('_spec.js', function() {
-  console.log('todo');
+const helper = require('../index.js');
+const lowerNode = require("../examples/nodes/lower-case.js");
+const RED = require('node-red');
 
-  it('should have credentials', function(done) {
-    helper.should.have.property('credentials');
-    done();
-  });
+// NOTE: Node-RED must be installed before running tests
+
+describe('_spec.js', function () {
+
+    const PROXY_METHODS = ['log', 'status', 'warn', 'error', 'debug', 'trace', 'send'];
+
+    it('should add spies to Node methods', done => {
+        const prefix = path.dirname(require.resolve('node-red'));
+        const NodePrototype = require(path.join(prefix, 'runtime', 'nodes', 'Node')).prototype;
+        Object.getOwnPropertyNames(NodePrototype).forEach(name => {
+            if (PROXY_METHODS.indexOf(name) != -1) {
+                NodePrototype[name].should.have.property('isSinonProxy', true);
+            }
+        });
+        done();
+    });
+
+    describe('load', () => {
+
+        afterEach(() => {
+            helper.unload();
+        });
+
+        it('should load test flow', function (done) {
+            var flow = [{ id: "n1", type: "lower-case", name: "lower-case" }];
+            helper.load(lowerNode, flow, function () {
+                done();
+            });
+        })
+
+        it('should register the helper node', function (done) {
+            var flow = [{ id: "n1", type: "lower-case", name: "lower-case" }];
+            helper.load(lowerNode, flow, function () {
+                let helperNode = RED.nodes.getType('helper');
+                if (helperNode) {
+                    return done();
+                }
+                done(new Error("helper should be registered"));
+            });
+        });
+
+        it('should get node under test', function (done) {
+            var flow = [{ id: "n1", type: "lower-case", name: "lower-case" }];
+            helper.load(lowerNode, flow, function () {
+                let lowerCaseNode = helper.getNode("n1");
+                if (lowerCaseNode) {
+                    return done();
+                }
+                done(new Error("couldn't get test node"));
+            });
+        });
+
+        it('should emit "call:send" event', done => {
+            var flow = [
+                { id: "n1", type: "lower-case", name: "test name", wires: [["n2"]] },
+                { id: "n2", type: "helper" }
+            ];
+            helper.load(lowerNode, flow, function () {
+                let n1 = helper.getNode("n1");
+                n1.on('call:send', call => {
+                    let msg = call.args[0];
+                    msg.should.have.property('payload', 'lowercase');
+                    done()
+                });
+                n1.receive({
+                    payload: 'LowerCase'
+                });
+            });
+        });
+
+        it('should emit "call:log" event', done => {
+
+            var logNode = function (RED) {
+                function LogNode(config) {
+                    RED.nodes.createNode(this, config);
+                    var node = this;
+                    node.on('input', function (msg) {
+                        node.log(msg.payload);
+                    });
+                }
+                RED.nodes.registerType("log", LogNode);
+            }
+
+            var flow = [
+                { id: "n1", type: "log", name: "test name", wires: [["n2"]] },
+                { id: "n2", type: "helper" }
+            ];
+            helper.load(logNode, flow, function () {
+                let n1 = helper.getNode("n1");
+                n1.on('call:log', call => {
+                    let log = call.args[0];
+                    log.should.eql('test log');
+                    done()
+                });
+                n1.receive({
+                    payload: 'test log'
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
to demonstrate new node ‘call:*’ events.  Used for checking node.log call.

Note that the range node is the only core node that currently needs changing to use this version of the helper; this example also serves as a reference for a required change to the core node tests when we publish this version.