### PR TITLE
Read settings.js from current working directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,9 +156,18 @@ class NodeTestHelper extends EventEmitter {
             }
         };
 
-        var settings = {
-            available: function() { return false; }
-        };
+        var settings;
+        try {
+            // Try to read settings.js from the current working directory.
+            var filePath = path.join(process.cwd(), "settings.js");
+            require.resolve(filePath);
+            settings = require(filePath);
+        } catch (err) {
+            // settings.js not found, set settings to not available.
+            settings = {
+                available: function() { return false; }
+            };
+        }
 
         var red = {
             _: v => v


### PR DESCRIPTION
At the moment it is impossible to test a flow which has a function node, which loads a module with a call to `global.get()`. (See the [documentation](https://nodered.org/docs/writing-functions#loading-additional-modules) on loading modules in function nodes.)

This PR adds the functionality, such that the test-helper loads a `settings.js` file from the current working directory (if present). Thus it will be possible to specify modules with `settings.functionGlobalContext`.