### PR TITLE
Allow helper to test the URL defined by http in node

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,6 +165,7 @@ class NodeTestHelper extends EventEmitter {
 
         const redNodes = this._redNodes;
         this._httpAdmin = express();
+        this._httpNode = express();
         const mockRuntime = {
             nodes: redNodes,
             events: this._events,
@@ -172,7 +173,7 @@ class NodeTestHelper extends EventEmitter {
             settings: this._settings,
             storage: storage,
             log: this._log,
-            nodeApp: express(),
+            nodeApp: this._httpNode,
             adminApp: this._httpAdmin,
             library: {register: function() {}},
             get server() { return self._server }
@@ -239,8 +240,12 @@ class NodeTestHelper extends EventEmitter {
         return this._redNodes.stopFlows();
     }
 
-    request() {
-        return request(this._httpAdmin);
+    request(app) {
+        if(app === "httpNode"){
+            return request(this._httpNode);
+        }else{
+            return request(this._httpAdmin);
+        }
     }
 
     startServer(done) {


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes

Currently `helper.request()` supports testing editor/admin URL, but it cannot request the URL which defined by `http in node`.
This is because `helper.request()` does not handle `runtime.httpNode` which routes a request to the path defined by the node.

I fixed it in order to support `runtime.httpNode`.
This PR will fix #29.

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [ ] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality
