### PR TITLE
Feature/add continuous integration/circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,3 +39,6 @@ jobs:
 
       # run tests!
       - run: yarn test
+
+      # run examples!
+      - run: yarn run examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,11 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
+      # Install latest deps and the version of node-red that is support by the
+      # node-red-node-test-help frameworker. We do this here rather than in the
+      # package.json.
       - run: yarn install
+      - run: yarn add node-red@0.20.0
 
       - save_cache:
           paths:


### PR DESCRIPTION
This adds CircleCI auto-test and running of the examples to node-red-node-test-helper.

Example of it running against my repo:
    https://circleci.com/gh/doublethefish/node-red-node-test-helper

In addition to the great benefits of using CI, part of the intent here is to demonstrate how to run the tests and examples, bolstering the pretty good documentation.