### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,14 +395,14 @@ Starts a Node-RED server for testing nodes that depend on http or web sockets en
 To start a Node-RED server before all test cases:
 
 ```javascript
-before(function(done) {
+beforeEach(function(done) {
     helper.startServer(done);
 });
 ```
 
 ### stopServer(done)
 
-Stop server.  Generally called after unload() complete.  For example, to unload a flow then stop a server after each test:
+Stop server. Generally called after unload() complete. For example, to unload a flow then stop a server after each test:
 
 ```javascript
 afterEach(function(done) {


### PR DESCRIPTION
Update readme for being consistent in startServer / stopServer calls. What the Readme currently states is OK with the start and stop definitions, but it is not consistent. 

If a developer tries copying/pasting now, it will fail.

With the proposed change, the server is started 'beforeEach' and 'afterEach' execution.