### PR TITLE
Fix async module loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 0.3.2
+ 
+ - Fix async module loading @knolleary
+
+
 #### 0.3.1
  
  - Add support for async node modules (#63) @knolleary

--- a/index.js
+++ b/index.js
@@ -234,7 +234,6 @@ class NodeTestHelper extends EventEmitter {
             library: {register: function() {}},
             get server() { return self._server }
         }
-
         redNodes.init(mockRuntime);
         redNodes.registerType("helper", function (n) {
             redNodes.createNode(this, n);
@@ -281,10 +280,9 @@ class NodeTestHelper extends EventEmitter {
                 }
             }
         });
-
         return Promise.all(initPromises)
-            .then(redNodes.loadFlows)
-            .then(redNodes.startFlows)
+            .then(() => redNodes.loadFlows())
+            .then(() => redNodes.startFlows())
             .then(() => {
                 should.deepEqual(testFlow, redNodes.getFlows().flows);
                 if(cb) cb();
@@ -299,7 +297,7 @@ class NodeTestHelper extends EventEmitter {
 
         // internal API
         this._context.clean({allNodes:[]});
-        return this._redNodes.stopFlows();
+        return this._redNodes.stopFlows()
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-test-helper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A test framework for Node-RED nodes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The fix introduced in #63 introduced a timing window where tests could be run against flows from the previous test.

This is because `loadFlows` was being called with the result of `Promise.all(...)` implicitly passed as the first arg. This was incorrectly getting it to start the flows prematurely.
