### PR TITLE
Fix: Wait for the runtime-deploy 'runtime-event' before starting flows

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,7 +281,18 @@ class NodeTestHelper extends EventEmitter {
             }
         });
         return Promise.all(initPromises)
-            .then(() => redNodes.loadFlows())
+            .then(() => {
+                const waitForDeploy = new Promise(resolve => {
+                    const deployListener = event => {
+                        if (event?.id === "runtime-deploy") {
+                            mockRuntime.events.removeListener("runtime-event", deployListener);
+                            resolve();
+                        }
+                    }
+                    mockRuntime.events.addListener("runtime-event", deployListener);
+                });
+                return redNodes.loadFlows().then(waitForDeploy);
+            })
             .then(() => redNodes.startFlows())
             .then(() => {
                 should.deepEqual(testFlow, redNodes.getFlows().flows);


### PR DESCRIPTION
We found some tests were failing randomly under certain conditions, but sometimes they worked.

Upon deeper analysis I found the NodeTestHelper.load() function awaits the loadFlows() promise to be fulfilled, but loadFlows() triggers setFlows in Node-RED which returns a 'configSavePromise' but within that promise, there is a start() call that is not awaited.

In order to make sure the flow is completely deployed, we need to await for the "runtime-event" event with id "runtime-deploy", before considering loadFlows() completed and proceeding to startFlows().

The "runtime-event" id === "runtime-deploy" event exists since version 0.16 of Node-RED. The helper initial version was for 0.18.2 already, thus, I do not judge important to check if Node-RED version supports this event.