### PR TITLE
Ensure hooks and plugins are included in the mock runtime api

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,6 +232,8 @@ class NodeTestHelper extends EventEmitter {
             nodeApp: express(),
             adminApp: this._httpAdmin,
             library: {register: function() {}},
+            hooks: this._RED.hooks,
+            plugins: this._RED.plugins,
             get server() { return self._server }
         }
         redNodes.init(mockRuntime);


### PR DESCRIPTION
Alternative fix to #73 - rather than stub it, expose the real internal plugin api.