### PR TITLE
Update supertest dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-node-test-helper",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A test framework for Node-RED nodes",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "should-sinon": "^0.0.6",
     "sinon": "^11.1.2",
     "stoppable": "^1.1.0",
-    "supertest": "^6.3.3"
+    "supertest": "^7.0.0"
   },
   "devDependencies": {
     "mocha": "^9.2.2"


### PR DESCRIPTION
fixes #75 

Major version bump drops support for Node <14.16.0 so no need for a big jump as this package is already <14