### PR TITLE
Update dependencies for 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 0.3.4
+
+ - Update dependencies
+
 #### 0.3.3
 
  - Add plugin stub to runtime (#73) @joepavitt

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "dependencies": {
     "body-parser": "^1.20.2",
-    "express": "^4.18.2",
-    "read-pkg-up": "^7.0.1",
+    "express": "^4.19.2",
     "semver": "^7.5.4",
     "should": "^13.2.3",
     "should-sinon": "^0.0.6",


### PR DESCRIPTION
Fixes #77 

Updates dependencies for 0.3.4 release
 - express
 - remove read-pkg-up as its fixed version is ESM only and only a few lines of code to implement